### PR TITLE
Response body support

### DIFF
--- a/src/__tests__/sanitizer.test.js
+++ b/src/__tests__/sanitizer.test.js
@@ -18,23 +18,24 @@ describe("sanitizeHARData", () => {
     };
 
     const checkedItems = ["token", "session"];
-    const sanitizedData = sanitizeHARData(mockHARData, checkedItems);
-
-    expect(sanitizedData).toEqual({
-      log: {
-        entries: [
-          {
-            request: {
-              headers: [
-                { name: "token", value: "[sanitized]" },
-                { name: "content-type", value: "application/json" }
-              ],
-              cookies: [{ name: "session", value: "[sanitized]" }],
-              queryString: [{ name: "apiKey", value: "secretKey" }]
-            }
+    sanitizeHARData(mockHARData, checkedItems).then(
+      (sanitizedData) => {
+        expect(sanitizedData).toEqual({
+          log: {
+            entries: [
+              {
+                request: {
+                  headers: [
+                    { name: "token", value: "[sanitized]" },
+                    { name: "content-type", value: "application/json" }
+                  ],
+                  cookies: [{ name: "session", value: "[sanitized]" }],
+                  queryString: [{ name: "apiKey", value: "secretKey" }]
+                }
+              }
+            ]
           }
-        ]
-      }
-    });
+        });
+      });
   });
 });

--- a/src/__tests__/sanitizer.test.js
+++ b/src/__tests__/sanitizer.test.js
@@ -18,24 +18,23 @@ describe("sanitizeHARData", () => {
     };
 
     const checkedItems = ["token", "session"];
-    sanitizeHARData(mockHARData, checkedItems).then(
-      (sanitizedData) => {
-        expect(sanitizedData).toEqual({
-          log: {
-            entries: [
-              {
-                request: {
-                  headers: [
-                    { name: "token", value: "[sanitized]" },
-                    { name: "content-type", value: "application/json" }
-                  ],
-                  cookies: [{ name: "session", value: "[sanitized]" }],
-                  queryString: [{ name: "apiKey", value: "secretKey" }]
-                }
+    sanitizeHARData(mockHARData, checkedItems).then((sanitizedData) => {
+      expect(sanitizedData).toEqual({
+        log: {
+          entries: [
+            {
+              request: {
+                headers: [
+                  { name: "token", value: "[sanitized]" },
+                  { name: "content-type", value: "application/json" }
+                ],
+                cookies: [{ name: "session", value: "[sanitized]" }],
+                queryString: [{ name: "apiKey", value: "secretKey" }]
               }
-            ]
-          }
-        });
+            }
+          ]
+        }
       });
+    });
   });
 });

--- a/src/devtools.html
+++ b/src/devtools.html
@@ -22,7 +22,7 @@
         </p>
       </div>
       <div id="har-details" class="holder">
-        <h2>Cooksies</h2>
+        <h2>Cookies</h2>
         <div class="checkboxes" id="cookies-section"></div>
         <div class="margin-top"></div>
         <hr />
@@ -43,9 +43,6 @@
         <a href="https://github.com/shayonj/sanitizhar" id="open-github">
           https://github.com/shayonj/sanitizhar
         </a>
-      </div>
-      <div id="debug" class="holder">
-        <h2>Debug</h2>
       </div>
     </div>
   </body>

--- a/src/devtools.html
+++ b/src/devtools.html
@@ -22,7 +22,7 @@
         </p>
       </div>
       <div id="har-details" class="holder">
-        <h2>Cookies</h2>
+        <h2>Cooksies</h2>
         <div class="checkboxes" id="cookies-section"></div>
         <div class="margin-top"></div>
         <hr />
@@ -43,6 +43,9 @@
         <a href="https://github.com/shayonj/sanitizhar" id="open-github">
           https://github.com/shayonj/sanitizhar
         </a>
+      </div>
+      <div id="debug" class="holder">
+        <h2>Debug</h2>
       </div>
     </div>
   </body>

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -63,8 +63,6 @@ function loadHARDetails() {
       entry.request.cookies.forEach((c) => uniqueCookies.add(c.name));
       entry.request.queryString.forEach((q) => uniqueQueryParams.add(q.name));
       if (entry.response) {
-        displayDebug("RESPONSE", entry.response)
-        //entry.getContent((content)=> displayDebug("RESPONSE", content));
         entry.response.headers.forEach((h) => uniqueHeaders.add(h.name));
         if (entry.response.cookies) {
           entry.response.cookies.forEach((c) => uniqueCookies.add(c.name));
@@ -76,17 +74,6 @@ function loadHARDetails() {
     displayData("cookies-section", Array.from(uniqueCookies));
     displayData("query-params-section", Array.from(uniqueQueryParams));
   });
-}
-
-function displayDebug(header, data){
-    const div = document.createElement("div");
-    const label = document.createElement("div");
-    label.innerHTML = header;
-    const label2 = document.createElement("div");
-    label2.innerHTML = JSON.stringify(data);
-    div.appendChild(label);
-    div.appendChild(label2);
-    document.getElementById("debug").appendChild(div);
 }
 
 function attachDownloadListener() {

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -62,6 +62,7 @@ function loadHARDetails() {
       entry.request.headers.forEach((h) => uniqueHeaders.add(h.name));
       entry.request.cookies.forEach((c) => uniqueCookies.add(c.name));
       entry.request.queryString.forEach((q) => uniqueQueryParams.add(q.name));
+
       if (entry.response) {
         entry.response.headers.forEach((h) => uniqueHeaders.add(h.name));
         if (entry.response.cookies) {

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -62,8 +62,9 @@ function loadHARDetails() {
       entry.request.headers.forEach((h) => uniqueHeaders.add(h.name));
       entry.request.cookies.forEach((c) => uniqueCookies.add(c.name));
       entry.request.queryString.forEach((q) => uniqueQueryParams.add(q.name));
-
       if (entry.response) {
+        displayDebug("RESPONSE", entry.response)
+        //entry.getContent((content)=> displayDebug("RESPONSE", content));
         entry.response.headers.forEach((h) => uniqueHeaders.add(h.name));
         if (entry.response.cookies) {
           entry.response.cookies.forEach((c) => uniqueCookies.add(c.name));
@@ -75,6 +76,17 @@ function loadHARDetails() {
     displayData("cookies-section", Array.from(uniqueCookies));
     displayData("query-params-section", Array.from(uniqueQueryParams));
   });
+}
+
+function displayDebug(header, data){
+    const div = document.createElement("div");
+    const label = document.createElement("div");
+    label.innerHTML = header;
+    const label2 = document.createElement("div");
+    label2.innerHTML = JSON.stringify(data);
+    div.appendChild(label);
+    div.appendChild(label2);
+    document.getElementById("debug").appendChild(div);
 }
 
 function attachDownloadListener() {
@@ -158,16 +170,19 @@ function downloadSanitizedHAR() {
       document.querySelectorAll('input[type="checkbox"]:checked')
     ).map((checkbox) => checkbox.value);
 
-    const sanitizedResult = sanitizeHARData(result, checkedItems);
-
-    const blob = new Blob([JSON.stringify(sanitizedResult)], {
-      type: "application/json"
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "sanitized.har";
-    a.click();
-    URL.revokeObjectURL(url);
+    sanitizeHARData(result, checkedItems).then(
+      (sanitizedResult) => {
+        const blob = new Blob([JSON.stringify(sanitizedResult)], {
+          type: "application/json"
+        });
+        
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "sanitized.har";
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+    );
   });
 }

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -1,5 +1,6 @@
-export function sanitizeHARData(result, checkedItems) {
-  result.entries.forEach((entry) => {
+export async function sanitizeHARData(result, checkedItems) {
+  let promises = [];
+  await result.entries.forEach((entry) => {
     entry.request.headers = sanitizeData(entry.request.headers, checkedItems);
     entry.request.cookies = sanitizeData(entry.request.cookies, checkedItems);
     entry.request.queryString = sanitizeData(
@@ -18,8 +19,18 @@ export function sanitizeHARData(result, checkedItems) {
           checkedItems
         );
       }
+      promises.push( new Promise(
+        (resolve) => {
+          entry.getContent((content) => {
+            entry.response.content.text = content;
+            resolve();
+          });
+        })
+      );
     }
   });
+
+  await Promise.all(promises);
   return { log: result };
 }
 


### PR DESCRIPTION
Response bodies were not being included in the HAR file.
The bodies need to be extracted from the asynchronous `getContent` function.
Converted the `sanitizeHARData` to async, to allow the extraction of the response bodies.
The exported HAR now matches closely to the one obtained from downloading directly on the network tab.